### PR TITLE
Updated object check when retrieving items from the acad calendar feed

### DIFF
--- a/includes/ucf-academic-calendar-feed.php
+++ b/includes/ucf-academic-calendar-feed.php
@@ -36,9 +36,11 @@ if ( ! class_exists( 'UCF_Acad_Cal_Feed' ) ) {
 				if ( is_array( $response ) ) {
 					$retobj = json_decode( wp_remote_retrieve_body( $response ) );
 
-					if ( is_array( $retobj->terms ) ) {
+					if ( is_array( $retobj->terms ) && 
+						 array_key_exists( 0, $retobj->terms ) &&
+						 property_exists( $retobj->terms[0], 'events' ) ) {
 						$items = $retobj->terms[0]->events;
-					}
+					} // else $items is still false
 				}
 
 				if ( $use_cache ) {


### PR DESCRIPTION
Bug Fixes:
* Updates the check to see if events exist on the feed response to check that the index exists within the results array **and** that the `events` property exists before trying to access it.